### PR TITLE
修复login读取空json

### DIFF
--- a/main.py
+++ b/main.py
@@ -498,14 +498,6 @@ class Ximalaya:
                 config = None# modify
                 for request in driver.requests:
                     if request.url == "https://www.ximalaya.com/m-revision/page/track/queryRelativeTracksById?trackId=62919401&preOffset=9&nextOffset=0&countKeys=play&order=2":
-                        # 如果文件不存在，创建默认配置 ##modify
-                        # 必须先有这个json结构，才能使用jsonload，不然会报错！
-                        # 不用加，analyze_config中有了
-                        # config_path = "config.json"
-                        # if not os.path.exists(config_path):
-                        #     default_config = {"cookie": "", "bid": ""}
-                        #     with open(config_path, "w", encoding="utf-8") as f:
-                        #         json.dump(default_config, f)
                         with open("config.json", "r", encoding="utf-8") as f:
                             config = json.load(f)
                         for key, value in request.headers.items():


### PR DESCRIPTION
但是每次 try 都要以 w 模式 open config 文件`try:with open("config.json", "w", encoding="utf-8") as f:`
**一旦通过 w 模式打开文件，文件立马被清空！**
所以之前初始化的操作全都没有用了！下一次 try 的时候，有了目标 url，进入 if 读取 json 就会报错。